### PR TITLE
Fixes stuff that's broken

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = function S3Router(options) {
    * give temporary access to PUT an object in an S3 bucket.
    */
   router.get('/sign', function * () {
-    if (!this.query.objectName || !this.query.fileName) {
+    if (!this.query.objectName && !this.query.fileName) {
       this.throw(400, 'Either objectName or fileName is required as a query parameter');
     }
     if (!this.query.contentType) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/ktonon/koa-s3-sign-upload#readme",
   "dependencies": {
     "aws-sdk": "^2.9.0",
-    "koa-router": "^7.1.0",
+    "koa-router": "^5.4.1",
     "node-uuid": "^1.4.7"
   }
 }


### PR DESCRIPTION
This downgrades koa-router to a version that's compatible with the generator function syntax of koa1. Also fixes a logic mistake in the query param checks. I'm not sure how this worked prior to these two fixes. But I've tested it out and I'm using it in a real-world app now, so this definitely works.

Koa1 ex.
```
const koa = require('koa'); //v1
const s3Sign = require('koa-s3-sign-upload');
const app = koa();
app.use(s3Sign({
  bucket: 'MySpecialBucket',
  region: 'us-east-1',
}));
```

Koa2 ex.
```
const Koa = require('koa'); //v2
const convert = require('koa-convert');
const s3Sign = require('koa-s3-sign-upload');
const app = new Koa();
app.use(convert(s3Sign({
  bucket: 'MySpecialBucket',
  region: 'us-east-1',
})));
```